### PR TITLE
Improve return value of `BootMouse.update`

### DIFF
--- a/adafruit_usb_host_mouse.py
+++ b/adafruit_usb_host_mouse.py
@@ -206,5 +206,4 @@ class BootMouse:
                 # it is being clicked.
                 pressed_btns.append(button)
 
-        if len(pressed_btns) > 0:
-            return pressed_btns
+        return tuple(pressed_btns)

--- a/adafruit_usb_host_mouse.py
+++ b/adafruit_usb_host_mouse.py
@@ -174,8 +174,9 @@ class BootMouse:
         Read data from the USB mouse and update the location of the visible cursor
         and check if any buttons are pressed.
 
-        :return: a List containing one or more of the strings "left", "right", "middle"
-          indicating which buttons are pressed.
+        :return: a tuple containing one or more of the strings "left", "right", "middle"
+          indicating which buttons are pressed. If no buttons are pressed, the tuple will be empty.
+          If a error occurred while trying to read from the usb device, `None` will be returned.
         """
         try:
             # attempt to read data from the mouse


### PR DESCRIPTION
Relatively simple fix here. The changes are as follows:
- `BootMouse.update` returns a `tuple` (immutable) rather than a `list` object
- If the device reads successfully and no buttons are pressed, an empty `tuple` is returned rather than `None`
- If an error is encountered during the device read, `None` is returned

Fixes https://github.com/adafruit/Adafruit_CircuitPython_USB_Host_Mouse/issues/8