### PR TITLE
add pressed_btns class property

### DIFF
--- a/adafruit_usb_host_mouse.py
+++ b/adafruit_usb_host_mouse.py
@@ -149,6 +149,11 @@ class BootMouse:
         """The sensitivity of the mouse cursor. Larger values will make
         the mouse cursor move slower relative to physical mouse movement. Default is 1."""
 
+        self.pressed_btns = []
+        """List of buttons currently pressed (one or more of "left", "right", "middle")
+        If there's no new mouse data (nothing changes) this property can be checked to see
+        which buttons are currently pressed."""
+
         self.display_size = (supervisor.runtime.display.width, supervisor.runtime.display.height)
 
     @property
@@ -218,13 +223,13 @@ class BootMouse:
             ),
         )
 
-        pressed_btns = []
+        self.pressed_btns = []
         for i, button in enumerate(BUTTONS):
             # check if each button is pressed using bitwise AND shifted
             # to the appropriate index for this button
             if self.buffer[0] & (1 << i) != 0:
                 # append the button name to the string to show if
                 # it is being clicked.
-                pressed_btns.append(button)
+                self.pressed_btns.append(button)
 
-        return tuple(pressed_btns)
+        return tuple(self.pressed_btns)


### PR DESCRIPTION
While adding a "chording" functionality to the minesweeper application I realized that the USB_Host_Mouse library didn't provide a way of determining if a mouse button was being held down or detecting when it is released.

By making the pressed_btns variable an accessible class property the calling application can now determine the current state of the button pushes after each call to the update method.

The start of the mouse update loop for minesweeper would be modified to the following which allows both the x,y coordinates and the current mouse button status to be monitored independently:
```py
mouse_tg = mouse.tilegrid

while True:
    update_ui()
    # update cursor position, and check for clicks
    mouse.update()
    buttons = mouse.pressed_btns

    # Extract button states
    if buttons is None or buttons == []:
        left_button = 0
        right_button = 0
    else:
        left_button = 1 if 'left' in buttons else 0
        right_button = 1 if 'right' in buttons else 0

    mouse_coords = (mouse_tg.x, mouse_tg.y)
```

Edit: Without these changes, if there is no mouse data (the mouse isn't moved and the button status doesn't change) when the update method is called a value of None is returned for the button values and the current state of the buttons is lost.

Edit: If the application is only interested in capturing button pushes and not the held or released status then the return value can be used as it had been before this update.