### PR TITLE
Add support for composite HID devices

### DIFF
--- a/adafruit_usb_host_mouse/__init__.py
+++ b/adafruit_usb_host_mouse/__init__.py
@@ -130,8 +130,7 @@ def find_and_init_report_mouse(cursor_image=DEFAULT_CURSOR):  # noqa: PLR0912
     and return it.
 
     :param cursor_image: Provide the absolute path to the desired cursor bitmap image. If set as
-      `None`, the :class:`ReportMouse` instance will not control
-              a :class:`displayio.TileGrid` object.
+      `None`, the :class:`ReportMouse` will not control a :class:`displayio.TileGrid` object.
     :return: The :class:`ReportMouse` instance or None if no mouse was found.
     """
     mouse_interface_index, mouse_endpoint_address = None, None


### PR DESCRIPTION
This is one of two library changes (Adafruit_USB_Host_Descriptors and Adafruit_CircuitPython_USB_Host_Mouse) that provides a framework to support combination keyboard/trackpad USB devices. A PR https://github.com/adafruit/Adafruit_Learning_System_Guides/pull/3169 to the Fruit Jam PyPaint application has also been submitted which shows the use of these changes from an application perspective

This change adds a new subclass of BootMouse, ReportMouse for not-boot mice, ie pointing devices on combination keyboards. There's also a new helper routine find_and_init_report_mouse which works the same as the existing find_and_init_boot_mouse which can be called if no boot mice are found.