### PR TITLE
add interface index to BOOTMOUSE class

### DIFF
--- a/adafruit_usb_host_mouse/__init__.py
+++ b/adafruit_usb_host_mouse/__init__.py
@@ -260,7 +260,7 @@ class BootMouse:
         Release the mouse cursor and re-attach it to the kernel
         if it was attached previously.
         """
-        # was_attached is a list of interfaces detached from the kernel or 
+        # was_attached is a list of interfaces detached from the kernel or
         # an empty list if no interfaces were detached
         for intf in self.was_attached:
             if not self.device.is_kernel_driver_active(intf):


### PR DESCRIPTION
I believe to properly work with non BOOT mice, the kernel driver detach/attach commands need to be called using the USB interface index of the mouse.

This PR adds the mouse interface index to the attributes of the BootMouse class and uses the index to detach the kernel driver before configuring the mouse.